### PR TITLE
fix: update sp1-zkvm dependency rev to v1.0.1 for programs

### DIFF
--- a/blob_inclusion/program/Cargo.toml
+++ b/blob_inclusion/program/Cargo.toml
@@ -5,7 +5,7 @@ name = "blob-inclusion-program"
 edition = "2021"
 
 [dependencies]
-sp1-zkvm = { git = "https://github.com/succinctlabs/sp1.git", tag = "v1.0.8-testnet" }
+sp1-zkvm = { git = "https://github.com/succinctlabs/sp1.git", rev = "v1.0.1" }
 nmt-rs = {git="https://github.com/Sovereign-Labs/nmt-rs.git", rev="ac03d7c", features=["serde"]}
 celestia-types = {git="https://github.com/eigerco/lumina.git", rev="8094d04"}
 tendermint = "0.35.0"

--- a/blobstream/program/Cargo.toml
+++ b/blobstream/program/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 alloy = { version = "0.1.1", default-features = false, features = [
     "sol-types",
 ] }
-sp1-zkvm = { git = "https://github.com/succinctlabs/sp1.git", rev = "e48c01ec" }
+sp1-zkvm = { git = "https://github.com/succinctlabs/sp1.git", rev = "v1.0.1" }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 bincode = "1.3.3"


### PR DESCRIPTION
This updates the sp1-zkvm dependency revision for the `blobstream` program, which is required for it to run correctly. It makes the same update in the `blob_inclusion` program for consistency.