### PR TITLE
Use a local "prover" to verify proofs

### DIFF
--- a/blob_inclusion/program/src/main.rs
+++ b/blob_inclusion/program/src/main.rs
@@ -64,7 +64,7 @@ pub fn main() {
         let data_root: Hash = sp1_zkvm::io::read();
         data_roots.push(data_root);
         // Read the block height
-        let block_height: u64 = sp1_zkvm::io::read();
+        let _block_height: u64 = sp1_zkvm::io::read();
         // Read num rows
         let num_rows: u32 = sp1_zkvm::io::read();
         // Read namespace ID

--- a/blob_inclusion/script/src/bin/prove.rs
+++ b/blob_inclusion/script/src/bin/prove.rs
@@ -202,6 +202,11 @@ fn main() -> anyhow::Result<()> {
         elapsed_time.as_secs()
     );
 
+    // Set up a local ProverClient which will only be used to verify the proof locally. 
+    // In this local() mode, this does not require a gnark-ffi Docker container.
+    let prover = ProverClient::local();
+    let (_, vkey) = prover.setup(ELF);
+
     // Verify proof.
     prover
         .verify(&proof, &vkey)

--- a/blobstream/script/src/bin/prove.rs
+++ b/blobstream/script/src/bin/prove.rs
@@ -1,6 +1,6 @@
 use blobstream_script::helper::*;
 use clap::Parser;
-use sp1_sdk::SP1Stdin;
+use sp1_sdk::{ProverClient, SP1Stdin};
 use tokio::runtime;
 
 #[derive(Parser, Debug)]
@@ -58,11 +58,13 @@ fn main() -> anyhow::Result<()> {
         elapsed_time.as_secs()
     );
 
+    // Set up a local ProverClient which will only be used to verify the proof locally. 
+    // In this local() mode, this does not require a gnark-ffi Docker container.
+    let pc = ProverClient::local();
+    let (_, vkey) = pc.setup(TENDERMINT_ELF);
+
     // Verify proof.
-    prover
-        .prover_client
-        .verify(&proof, &prover.vkey)
-        .expect("Verification failed");
+    pc.verify(&proof, &vkey).expect("Verification failed");
 
     // Save the proof as binary.
     proof


### PR DESCRIPTION
This PR uses SP1's `ProverClient::local();` to create a local prover in order to verify the blobstream and blob inclusion proofs after they are generated without needing the gnark-ffi Docker image.

Previously, the prover was the `network` version as set by an environment variable in `.env`. That is necessary to invoke the SP1 prover network to generate the proof, but its default behaviour for verification is to launch a Docker container.

I also tweaked a variable name in a separate file to silence an unused-variable compilation warning.